### PR TITLE
Update graphite-cleaner to work with Python 3.10

### DIFF
--- a/graphite_cleaner/main.py
+++ b/graphite_cleaner/main.py
@@ -62,7 +62,7 @@ def remove_empty_folders(path):
         for dirname in dirnames:
             try:
                 os.rmdir(os.path.realpath(os.path.join(root, dirname)))
-                print GREEN.format('[REMOVED]'), os.path.join(root, dirname)
+                print(GREEN.format('[REMOVED]'), os.path.join(root, dirname))
             except OSError as exception:
                 if exception.errno != errno.ENOTEMPTY:
                     raise
@@ -89,56 +89,56 @@ def parse_ignore_file(f):
      help='file containing regex patterns specyfing paths to ignore',
      default='/etc/graphite-cleaner/ignore.lst')
 @arg('-l', '--loglevel', default='ERROR')
-def remove_stale_files(args):
-    logger.setLevel(logging.getLevelName(args.loglevel))
+def remove_stale_files(*args, **kwargs):
+    logger.setLevel(logging.getLevelName(kwargs['loglevel']))
 
-    print 'Graphite Whisper stale database files remover\n'
+    print('Graphite Whisper stale database files remover\n')
 
     ignore_patterns = None
 
-    if args.ignorefile:
-        if os.path.exists(args.ignorefile):
-            ignore_patterns = parse_ignore_file(open(args.ignorefile))
+    if kwargs['ignorefile']:
+        if os.path.exists(kwargs['ignorefile']):
+            ignore_patterns = parse_ignore_file(open(kwargs['ignorefile']))
         else:
-            print 'Ignore file %s does not exist.' % args.ignorefile
+            print('Ignore file %s does not exist.' % kwargs['ignorefile'])
 
-    files, size, total_size = get_stale_files(args.path, args.days, ignore_patterns)
+    files, size, total_size = get_stale_files(kwargs['path'], kwargs['days'], ignore_patterns)
 
     if not files:
-        print 'No deletable files found.'
+        print('No deletable files found.')
         return
 
     for file_path in files:
-        print file_path
+        print(file_path)
 
     print('Found {count} files. '
-          'Size: {size:.2f}MB/{total_size:.2f}MB ({percent:.2%})').format(
+          'Size: {size:.2f}MB/{total_size:.2f}MB ({percent:.2%})'.format(
               size=size / BYTES_TO_MEGABYTES,
               total_size=total_size / BYTES_TO_MEGABYTES,
               percent=float(size) / total_size if total_size != 0 else 0,
-              count=len(files))
+              count=len(files)))
 
-    if args.dry_run:
+    if kwargs['dry_run']:
         return
 
-    if not args.noinput:
-        print YELLOW.format('The files listed above are going to be removed. '
-                            'Continue? [y/N]')
-        choice = raw_input().lower()
+    if not kwargs['noinput']:
+        print(YELLOW.format('The files listed above are going to be removed. '
+                            'Continue? [y/N]'))
+        choice = input().lower()
 
         if choice != 'y':
-            print YELLOW.format('Operation aborted.')
+            print(YELLOW.format('Operation aborted.'))
             return
 
     for file_path in files:
         try:
             os.remove(file_path)
-            print GREEN.format('[REMOVED]'), file_path
+            print(GREEN.format('[REMOVED]'), file_path)
         except OSError as exception:
-            print RED.format('[ERROR]'), file_path
-            print exception
-    remove_empty_folders(args.path)
-    print 'Finished.'
+            print(RED.format('[ERROR]'), file_path)
+            print(exception)
+    remove_empty_folders(kwargs['path'])
+    print('Finished.')
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
         'graphite-cleaner = graphite_cleaner.main:main']
     },
     install_requires=[
-        'argh==0.24.1'
+        'argh==0.26.2'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='graphite-cleaner',
-    version='0.1.2',
+    version='0.1.3',
     description='Graphite Whisper stale database files remover',
     author='Services Wroclaw Team',
     author_email='svc-code@opera.com',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- Add a giphy that embodies the Soul of your PR... Or something cool -->
![](https://media.giphy.com/media/5tvJS6ZZslR9nBYxUA/giphy.gif)

## Description
Was attempting to make use of this script with a docker image based on Python3. Ran into a few issues due to changes in Python since the script was written. This PR fixes these issues as well as upgrades argh to its latest version 

### Notes
- None

## How Has This Been Tested?
The `setup.py` process installs the script correct and the script preform correctly in a docker image build against Python 3.10
